### PR TITLE
Adjust tag dimensions to match template

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@
       :root {
         --page-width: 21cm;
         --page-height: 29.7cm;
-        --page-padding-top: 1.35cm;
-        --page-padding-right: 1.05cm;
-        --page-padding-bottom: 1.35cm;
-        --page-padding-left: 1.05cm;
-        --column-gap: 0.7cm;
-        --row-gap: 0.6cm;
-        --tag-width: 9cm;
-        --tag-height: 4.8cm;
+        --page-padding-top: 1.9cm;
+        --page-padding-right: 0cm;
+        --page-padding-bottom: 1.9cm;
+        --page-padding-left: 0cm;
+        --column-gap: 0cm;
+        --row-gap: 0cm;
+        --tag-width: 10.5cm;
+        --tag-height: 3.7cm;
         --tag-bg: #050505;
         --tag-text: #ffffff;
         --pill-bg: #ffffff;
@@ -258,7 +258,7 @@
         column-gap: var(--column-gap);
         row-gap: var(--row-gap);
         justify-content: center;
-        align-content: center;
+        align-content: start;
       }
 
       .label {


### PR DESCRIPTION
## Summary
- update the print layout variables so each tag is 10.5×3.7 cm with zero spacing and 1.9 cm page margins
- pin the label grid to the top padding so the sheet lines up with the template margins

## Testing
- node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({args: ['--no-sandbox']});
  const page = await browser.newPage();
  await page.goto('file://' + process.cwd() + '/index.html', { waitUntil: 'load' });
  await page.evaluate(() => {
    const sheet = document.getElementById('tagSheet');
    const clone = sheet.cloneNode(true);
    document.body.innerHTML = '';
    document.body.style.margin = '0';
    document.documentElement.style.margin = '0';
    document.body.appendChild(clone);
    clone.style.margin = '0';
    clone.style.boxShadow = 'none';
  });
  await page.pdf({ path: 'members-price-tags-sheet.pdf', width: '21cm', height: '29.7cm', printBackground: true, margin: {top: 0, right: 0, bottom: 0, left: 0} });
  await browser.close();
})();
NODE
- pdftoppm -png -r 300 members-price-tags-sheet.pdf members-price-tags-sheet
- python - <<'PY'
from PIL import Image
import numpy as np
img = Image.open('members-price-tags-sheet-1.png').convert('L')
arr = np.array(img)
mask = arr < 150
rows = mask.sum(axis=1)
cols = mask.sum(axis=0)
row_indices = np.where(rows > 50)[0]
col_indices = np.where(cols > 50)[0]
start = row_indices[0]
end = row_indices[-1] + 1
height = end - start
width = col_indices[-1] - col_indices[0] + 1
pixels_per_cm = 300 / 2.54
print('Top margin pixels:', start)
print('Bottom margin pixels:', arr.shape[0] - end)
print('Height per row:', height / 5, 'px', height / 5 / pixels_per_cm, 'cm')
print('Width per column:', width / 2, 'px', width / 2 / pixels_per_cm, 'cm')
PY

------
https://chatgpt.com/codex/tasks/task_e_68cb2549ebe8832fb8c23a62a3c7f379