### PR TITLE
Align label layout with template design

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,45 +264,54 @@
       .label {
         width: var(--tag-width);
         height: var(--tag-height);
-        display: flex;
+        display: grid;
+        grid-template-columns: 3.7cm 1fr;
+        background: #ffffff;
+        border-radius: 0.38cm;
+        overflow: hidden;
       }
 
       .label-card {
         background: var(--tag-bg);
         color: var(--tag-text);
-        border-radius: 0.38cm;
-        padding: 0.45cm 0.55cm 0.5cm;
+        padding: 0.2cm 0.44cm 0.2cm;
         display: flex;
         flex-direction: column;
+        align-items: flex-start;
+        gap: 0.09cm;
         width: 100%;
         height: 100%;
+        border-radius: 0.38cm 0 0 0.38cm;
+      }
+
+      .label-blank {
+        background: #ffffff;
       }
 
       .tag-heading {
-        font-size: 0.95cm;
-        letter-spacing: 0.08em;
+        font-size: 0.54cm;
+        letter-spacing: 0.16em;
         text-transform: uppercase;
         font-weight: 700;
-        line-height: 1;
+        line-height: 0.95;
       }
 
       .price {
-        margin-top: 0.32cm;
         font-family: var(--display-font);
-        font-size: 2.05cm;
-        line-height: 1;
+        font-size: 1.22cm;
+        line-height: 0.8;
         font-weight: 800;
         letter-spacing: 0.01em;
       }
 
       .unit-line {
-        margin-top: 0.22cm;
-        font-size: 0.55cm;
-        letter-spacing: 0.03em;
+        font-size: 0.33cm;
+        letter-spacing: 0.06em;
         font-weight: 600;
         color: rgba(255, 255, 255, 0.9);
         display: flex;
-        gap: 0.2cm;
+        gap: 0.1cm;
+        align-items: baseline;
       }
 
       .unit-separator {
@@ -315,14 +324,14 @@
         background: var(--pill-bg);
         color: var(--pill-text);
         border-radius: 999px;
-        padding: 0.2cm 0.6cm;
-        font-size: 0.48cm;
+        padding: 0.1cm 0.36cm;
+        font-size: 0.28cm;
         font-weight: 700;
-        letter-spacing: 0.05em;
+        letter-spacing: 0.08em;
         text-transform: uppercase;
         display: inline-flex;
         align-items: center;
-        gap: 0.25cm;
+        gap: 0.09cm;
       }
 
       .price[data-empty='true'],
@@ -450,6 +459,7 @@
                 <span class="expiry-date" data-role="end-date">${placeholders.endDate}</span>
               </div>
             </div>
+            <div class="label-blank" aria-hidden="true"></div>
           `;
           const priceEl = label.querySelector('[data-role="price"]');
           const unitPriceEl = label.querySelector('[data-role="unit-price"]');


### PR DESCRIPTION
## Summary
- restructure each label into a black left panel with a blank right panel to mirror the supplied template
- adjust typography, spacing, and the expiry pill so the content fits inside the 10.5cm × 3.7cm area without clipping
- keep the preview/grid logic intact while injecting the new blank panel element for every generated label

## Testing
- Manual visual check in browser

------
https://chatgpt.com/codex/tasks/task_e_68cb2c84f54c832fb3f182e265939a07