### PR TITLE
Center label card content and fix heading case

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,8 @@
         padding: 0.24cm 0.44cm 0.24cm;
         display: flex;
         flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
+        text-align: center;
         gap: 0.09cm;
         width: 100%;
         height: 100%;
@@ -294,7 +295,7 @@
         font-family: var(--heading-font);
         font-size: 0.48cm;
         letter-spacing: 0.05em;
-        text-transform: uppercase;
+        text-transform: none;
         font-weight: 400;
         line-height: 1;
         white-space: nowrap;
@@ -317,6 +318,7 @@
         display: flex;
         gap: 0.1cm;
         align-items: baseline;
+        justify-content: center;
       }
 
       .unit-separator {
@@ -325,7 +327,7 @@
 
       .expiry-pill {
         margin-top: auto;
-        align-self: flex-start;
+        align-self: center;
         background: var(--pill-bg);
         color: var(--pill-text);
         border-radius: 999px;


### PR DESCRIPTION
## Summary
- center the content within the label card so the layout no longer appears clipped
- display the tag heading as "Members Price" instead of forcing all-uppercase text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb3dfd9958832fbdef0517b835608a