### PR TITLE
Fix expiry pill text clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,16 +337,22 @@
         background: var(--pill-bg);
         color: var(--pill-text);
         border-radius: 999px;
-        padding: 0.08cm 0.32cm;
+        padding: 0.12cm 0.36cm;
         font-size: 0.24cm;
         font-weight: 700;
         letter-spacing: 0.06em;
         text-transform: uppercase;
         display: inline-flex;
         align-items: center;
+        justify-content: center;
         gap: 0.06cm;
         max-width: 100%;
         white-space: nowrap;
+        line-height: 1;
+      }
+
+      .expiry-pill span {
+        line-height: 1;
       }
 
       .expiry-date {


### PR DESCRIPTION
## Summary
- increase the expiry pill's vertical padding and enforce a unit line height so the text can sit comfortably inside the pill
- center the inline flex content horizontally to keep the label and date balanced

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb45c7e484832f9dc89fdc88c69bd0