### PR TITLE
Use FontNumbers font for price labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,14 @@
       rel="stylesheet"
     />
     <style>
+      @font-face {
+        font-family: 'FontNumbers';
+        src: url('FontNumbers.dfont') format('truetype');
+        font-weight: normal;
+        font-style: normal;
+        font-display: swap;
+      }
+
       :root {
         --page-width: 21cm;
         --page-height: 29.7cm;
@@ -27,7 +35,7 @@
         --pill-bg: #ffffff;
         --pill-text: #111827;
         --body-font: 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
-        --display-font: 'Barlow Condensed', 'Impact', sans-serif;
+        --display-font: 'FontNumbers', 'Barlow Condensed', 'Impact', sans-serif;
         --heading-font: 'Impact', 'Impact Regular', 'Arial Black', sans-serif;
       }
 


### PR DESCRIPTION
## Summary
- load the bundled FontNumbers font via @font-face
- apply the FontNumbers typeface to the price display while preserving existing fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb471e4d04832fbaaf86e3f535f43a