### PR TITLE
Fix custom font loading for price display

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <style>
       @font-face {
         font-family: 'FontNumbers';
-        src: url('FontNumbers.dfont') format('truetype');
+        src: url('CoopFontNumbers.ttf') format('truetype');
         font-weight: normal;
         font-style: normal;
         font-display: swap;


### PR DESCRIPTION
## Summary
- load the custom price font from the provided CoopFontNumbers.ttf file so browsers render the intended glyphs

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68cb4da59fa0832f9030ed42c6518623