### PR TITLE
Adjust price scaling for multi-digit amounts

### DIFF
--- a/index.html
+++ b/index.html
@@ -760,8 +760,8 @@
         const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
         const PRICE_DOUBLE_DIGIT_THRESHOLD = 9.99;
         const PRICE_TRIPLE_DIGIT_THRESHOLD = 99.99;
-        const PRICE_DOUBLE_DIGIT_SCALE = 0.86;
-        const PRICE_TRIPLE_DIGIT_SCALE = 0.72;
+        const PRICE_DOUBLE_DIGIT_SCALE = 0.8;
+        const PRICE_TRIPLE_DIGIT_SCALE = 0.67;
 
         function createLabel(index) {
           const label = document.createElement('div');


### PR DESCRIPTION
## Summary
- reduce the automatic scale applied to double- and triple-digit prices so longer prices have more side margin on the label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbc8676ae4832fba15c0f720918a1b