### PR TITLE
Delay print call until preview is ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -1259,16 +1259,31 @@
           printButton.addEventListener('click', () => {
             const shouldHideAfter = !previewVisible;
 
+            const performPrint = () => {
+              updateAllLabels();
+
+              try {
+                window.print();
+              } finally {
+                if (shouldHideAfter) {
+                  setPreviewVisibility(false);
+                }
+              }
+            };
+
             if (shouldHideAfter) {
               setPreviewVisibility(true);
+
+              const schedule =
+                typeof window.requestAnimationFrame === 'function'
+                  ? window.requestAnimationFrame.bind(window)
+                  : (callback) => setTimeout(callback, 0);
+
+              schedule(() => {
+                schedule(performPrint);
+              });
             } else {
-              updateAllLabels();
-            }
-
-            window.print();
-
-            if (shouldHideAfter) {
-              setPreviewVisibility(false);
+              performPrint();
             }
           });
         }


### PR DESCRIPTION
## Summary
- wait until the preview layout has rendered before calling `window.print()` to avoid blank sheets when the preview was hidden
- ensure the preview is restored after printing even if an error occurs and provide a `requestAnimationFrame` fallback

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbca315458832fa5f3b1d1c8c6bf1f