### PR TITLE
Ensure tag heading font loads on Android

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@600;700;800&family=Montserrat:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;600;700;800&family=Montserrat:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <style>
@@ -37,7 +37,7 @@
         --pill-text: #111827;
         --body-font: 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
         --display-font: 'FontNumbers', 'Barlow Condensed', 'Impact', sans-serif;
-        --heading-font: 'Impact', 'Impact Regular', 'Arial Black', sans-serif;
+        --heading-font: 'Impact', 'Impact Regular', 'Barlow Condensed', 'Arial Black', sans-serif;
         --heading-height-scale: 1.15;
         --price-scale: 1;
         --unit-height-scale: 1;


### PR DESCRIPTION
## Summary
- request regular weights for Barlow Condensed and Montserrat so the intended fonts are available on Android
- include Barlow Condensed in the heading font stack to provide a reliable web font fallback for the tag heading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd5898b48832fba1a5744f87847b7