### PR TITLE
Fix PDF download flow and remove export margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -724,7 +724,12 @@
       </section>
     </main>
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
@@ -1183,13 +1188,26 @@
           updateAllLabels();
         });
 
-        const pdfOptions = {
-          margin: 0,
-          filename: 'members-price-tags.pdf',
-          image: { type: 'jpeg', quality: 0.98 },
-          html2canvas: { scale: 2, useCORS: true, scrollX: 0, scrollY: 0 },
-          jsPDF: { unit: 'cm', format: 'a4', orientation: 'portrait' },
+        const PDF_EXPORT_FILENAME = 'members-price-tags.pdf';
+        const PDF_PAGE_SETTINGS = { unit: 'cm', format: 'a4', orientation: 'portrait' };
+        const HTML2CANVAS_EXPORT_OPTIONS = {
+          backgroundColor: '#ffffff',
+          scale: 2,
+          useCORS: true,
+          scrollX: 0,
+          scrollY: 0,
+          logging: false,
         };
+
+        function getJsPdfConstructor() {
+          if (window.jspdf && typeof window.jspdf.jsPDF === 'function') {
+            return window.jspdf.jsPDF;
+          }
+          if (typeof window.jsPDF === 'function') {
+            return window.jsPDF;
+          }
+          return null;
+        }
 
         const downloadButton = document.getElementById('downloadPdf');
 
@@ -1200,10 +1218,20 @@
               return;
             }
 
-            const pdfGenerator = window.html2pdf;
-            if (typeof pdfGenerator !== 'function') {
+            const html2canvasFn = window.html2canvas;
+            const JsPdfConstructor = getJsPdfConstructor();
+
+            if (typeof html2canvasFn !== 'function' || typeof JsPdfConstructor !== 'function') {
               alert('Unable to generate the PDF right now. Please try using the print option instead.');
               return;
+            }
+
+            if (document.fonts && document.fonts.ready) {
+              try {
+                await document.fonts.ready;
+              } catch (fontError) {
+                console.warn('Failed to wait for fonts before PDF export', fontError);
+              }
             }
 
             updateAllLabels();
@@ -1250,7 +1278,15 @@
             window.scrollTo(0, 0);
 
             try {
-              await pdfGenerator().set(pdfOptions).from(target).save();
+              const canvas = await html2canvasFn(target, HTML2CANVAS_EXPORT_OPTIONS);
+              const imageData = canvas.toDataURL('image/jpeg', 0.98);
+
+              const pdf = new JsPdfConstructor(PDF_PAGE_SETTINGS);
+              const pageWidth = pdf.internal.pageSize.getWidth();
+              const pageHeight = pdf.internal.pageSize.getHeight();
+
+              pdf.addImage(imageData, 'JPEG', 0, 0, pageWidth, pageHeight, undefined, 'FAST');
+              pdf.save(PDF_EXPORT_FILENAME);
             } catch (error) {
               console.error('Failed to generate PDF', error);
               alert('Sorry, there was a problem generating the PDF. Please try again.');


### PR DESCRIPTION
## Summary
- replace the html2pdf helper with html2canvas plus jsPDF so the download button works immediately
- wait for web fonts before capturing, reuse the hidden clone workflow, and disable extra logging during export
- add the required CDN scripts so the rendered PDF has no unexpected left margin after filling data

## Testing
- browser_container.run_playwright_script (Playwright PDF download completed)

------
https://chatgpt.com/codex/tasks/task_e_68ce9c1b7738832fbeac3a276fb2354f