### PR TITLE
Fix HP offset layout to keep second column aligned

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         --row-gap: 0cm;
         --tag-width: 10.5cm;
         --layout-offset: 0cm;
-        --tag-width-first: calc(var(--tag-width) - var(--layout-offset));
+        --tag-width-first: var(--tag-width);
         --tag-width-second: var(--tag-width);
         --tag-height: 3.7cm;
         --tag-bg: #00A1CC;
@@ -86,11 +86,13 @@
       body[data-layout-mode='full-bleed'] {
         --layout-offset: 0cm;
         --page-padding-left: 0cm;
+        --tag-width-first: var(--tag-width);
       }
 
       body[data-layout-mode='hp-offset'] {
         --layout-offset: 0.5cm;
         --page-padding-left: var(--layout-offset);
+        --tag-width-first: calc(var(--tag-width) - var(--layout-offset));
       }
 
       @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- ensure the HP Offset layout only reduces the first column width while keeping the second column fixed
- override the first-column width variable per layout mode so the new offset no longer pushes the second column

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68cfd6436e08832fa227c71c18a863ff