### PR TITLE
Adjust A4 product description alignment and badge placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         --a4-product-font-size: 1.168cm;
         --a4-product-letter-spacing: 0.012em;
         --a4-product-margin-top: 2.64cm;
-        --a4-product-translate-x: -2cm;
+        --a4-product-translate-x: 0cm;
       }
 
       *,
@@ -951,7 +951,7 @@
         width: 100%;
         display: flex;
         align-items: flex-start;
-        justify-content: center;
+        justify-content: flex-start;
         margin-top: var(--a4-product-margin-top);
       }
 
@@ -962,9 +962,14 @@
         color: #000000;
         font-weight: 400;
         margin: 0;
-        text-align: center;
+        text-align: left;
         line-height: 1.15;
         transform: translateX(var(--a4-product-translate-x));
+      }
+
+      body[data-paper-size='a4-single'] .drink-aware-badge {
+        left: auto;
+        right: 1.2cm;
       }
 
       .label.is-placeholder {
@@ -1597,7 +1602,7 @@
             label: 'Horizontal offset (cm)',
             varName: '--a4-product-translate-x',
             unit: 'cm',
-            default: -2,
+            default: 0,
             min: -10,
             max: 10,
             step: 0.01,


### PR DESCRIPTION
## Summary
- align the A4 product description with the left edge by default and update the tuning controls
- move the Drinkaware badge to the bottom-right corner on the A4 layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f100a4432c832fa982c18a89aecdff