### PR TITLE
Double Drinkaware badge size

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,8 +787,8 @@
         position: absolute;
         left: 1.2cm;
         bottom: 1.2cm;
-        width: 2.4cm;
-        max-width: 22%;
+        width: 4.8cm;
+        max-width: 44%;
         height: auto;
         object-fit: contain;
         pointer-events: none;


### PR DESCRIPTION
## Summary
- double the Drinkaware badge width constraints so it renders at twice the original size

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f106a2e898832f959d0cd3daddbefb